### PR TITLE
fix energytick update with Vigor/Ancient Brutality talents

### DIFF
--- a/modules/energytick.lua
+++ b/modules/energytick.lua
@@ -69,7 +69,7 @@ pfUI:RegisterModule("turtle-energytick", "vanilla:tbc", function ()
         else
           this.badtick = diff
         end
-      elseif this.mode == "ENERGY" and diff > 0 then
+      elseif this.mode == "ENERGY" and diff >= 14 then
         -- Use dynamic tick rate for energy
         this.energyTickRate = GetEnergyTickRate()
         this.target = this.energyTickRate


### PR DESCRIPTION
Right now the spark gets reset whenever any amount of energy is gained, rendering it useless if these talents are taken. By changing the threshold to a minimal amount that you can normally get per tick(14 as a rogue with active blade flurry), this issue is more or less eliminated.

Not familiar with druid, so not sure if this change is gonna break something for that class